### PR TITLE
implement cast_slice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ branches:
 
 matrix:
   fast_finish: true
+  allow_failures:
+  - rust: nightly
 
 script:
+  - rustup component add clippy
+  - cargo clippy --all --all-features --all-targets -- -D warnings
   - cargo -vv build
   - cargo -vv test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,6 +27,7 @@ install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init -y --default-toolchain %channel% --default-host %target%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
+  - rustup component add clippy
   - rustc -vV
   - cargo -vV
 
@@ -34,7 +35,6 @@ install:
 build: false
 
 test_script:
-  - rustup component add clippy
   - cargo clippy --all --all-features --all-targets -- -D warnings
   - cargo -vv build
   - cargo -vv test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ matrix:
 
 environment:
   matrix:
-    - allow_failures: nightly
     - channel: stable
       target: x86_64-pc-windows-msvc
     - channel: stable
@@ -27,6 +26,10 @@ environment:
       target: x86_64-pc-windows-msvc
     - channel: nightly
       target: i686-pc-windows-msvc
+
+matrix:
+  allow_failures:
+    - channel: nightly
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,19 +14,39 @@ matrix:
 
 environment:
   matrix:
-    - channel: stable
-      target: x86_64-pc-windows-msvc
-    - channel: stable
-      target: i686-pc-windows-msvc
-    - channel: beta
-      target: x86_64-pc-windows-msvc
-    - channel: beta
-      target: i686-pc-windows-msvc
-    - allow_failures:
-      - channel: nightly
-        target: x86_64-pc-windows-msvc
-      - channel: nightly
-        target: i686-pc-windows-msvc
+  # stable
+  - host: x86_64-pc-windows-msvc
+    targets: aarch64-pc-windows-msvc
+    channel: stable
+  - host: i686-pc-windows-msvc
+    channel: stable
+  - host: x86_64-pc-windows-gnu
+    channel: stable
+  - host: i686-pc-windows-gnu
+    channel: stable
+  # beta
+  - host: x86_64-pc-windows-msvc
+    targets: aarch64-pc-windows-msvc
+    channel: beta
+  - host: i686-pc-windows-msvc
+    channel: beta
+  - host: x86_64-pc-windows-gnu
+    channel: beta
+  - host: i686-pc-windows-gnu
+    channel: beta
+  # nightly
+  - host: x86_64-pc-windows-msvc
+    targets: aarch64-pc-windows-msvc
+    channel: nightly
+  - host: i686-pc-windows-msvc
+    channel: nightly
+  - host: x86_64-pc-windows-gnu
+    channel: nightly
+  - host: i686-pc-windows-gnu
+    channel: nightly
+matrix:
+  allow_failures:
+    - channel: nightly
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,47 +14,14 @@ matrix:
 
 environment:
   matrix:
-  # stable
-  - host: x86_64-pc-windows-msvc
-    targets: aarch64-pc-windows-msvc
-    channel: stable
-  - host: i686-pc-windows-msvc
-    channel: stable
-  - host: x86_64-pc-windows-gnu
-    channel: stable
-  - host: i686-pc-windows-gnu
-    channel: stable
-  # beta
-  - host: x86_64-pc-windows-msvc
-    targets: aarch64-pc-windows-msvc
-    channel: beta
-  - host: i686-pc-windows-msvc
-    channel: beta
-  - host: x86_64-pc-windows-gnu
-    channel: beta
-  - host: i686-pc-windows-gnu
-    channel: beta
-  # nightly
-  - host: x86_64-pc-windows-msvc
-    targets: aarch64-pc-windows-msvc
-    channel: nightly
-  - host: i686-pc-windows-msvc
-    channel: nightly
-  - host: x86_64-pc-windows-gnu
-    channel: nightly
-  - host: i686-pc-windows-gnu
-    channel: nightly
-matrix:
-  allow_failures:
-    - host: x86_64-pc-windows-msvc
-      targets: aarch64-pc-windows-msvc
-      channel: nightly
-    - host: i686-pc-windows-msvc
-      channel: nightly
-    - host: x86_64-pc-windows-gnu
-      channel: nightly
-    - host: i686-pc-windows-gnu
-      channel: nightly
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+    - channel: beta
+      target: x86_64-pc-windows-msvc
+    - channel: stable
+      target: x86_64-pc-windows-gnu
+    - channel: beta
+      target: x86_64-pc-windows-gnu
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,15 @@ environment:
     channel: nightly
 matrix:
   allow_failures:
-    - channel: nightly
+    - host: x86_64-pc-windows-msvc
+      targets: aarch64-pc-windows-msvc
+      channel: nightly
+    - host: i686-pc-windows-msvc
+      channel: nightly
+    - host: x86_64-pc-windows-gnu
+      channel: nightly
+    - host: i686-pc-windows-gnu
+      channel: nightly
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ matrix:
 
 environment:
   matrix:
+    - allow_failures: nightly
     - channel: stable
       target: x86_64-pc-windows-msvc
     - channel: stable
@@ -38,5 +39,7 @@ install:
 build: false
 
 test_script:
+  - rustup component add clippy
+  - cargo clippy --all --all-features --all-targets -- -D warnings
   - cargo -vv build
   - cargo -vv test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,14 +22,11 @@ environment:
       target: x86_64-pc-windows-msvc
     - channel: beta
       target: i686-pc-windows-msvc
-    - channel: nightly
-      target: x86_64-pc-windows-msvc
-    - channel: nightly
-      target: i686-pc-windows-msvc
-
-matrix:
-  allow_failures:
-    - channel: nightly
+    - allow_failures:
+      - channel: nightly
+        target: x86_64-pc-windows-msvc
+      - channel: nightly
+        target: i686-pc-windows-msvc
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,4 @@
 error_on_line_overflow = false
-fn_args_density = "Compressed"
 merge_imports = true
 reorder_imports = true
 use_try_shorthand = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,11 +120,6 @@ impl_unsafe_marker_for_array!(
   25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256, 512, 1024
 );
 
-/// As [try_cast_slice](try_cast_slice), but unwraps the result for you.
-pub fn cast_slice<A: Pod, B: Pod>(s: &[A]) -> &[B] {
-  try_cast_slice(s).unwrap()
-}
-
 /// The things that can go wrong when casting a slice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SliceCastError {
@@ -145,6 +140,7 @@ pub enum SliceCastError {
 /// Try to convert a slice of one type into another.
 ///
 /// * `input.as_ptr() as usize == output.as_ptr() as usize`
+/// * `input.len() * size_of::<A>() == output.len() * size_of::<B>()`
 ///
 /// ## Failure
 ///
@@ -179,4 +175,9 @@ pub fn try_cast_slice<A: Pod, B: Pod>(a: &[A]) -> Result<&[B], SliceCastError> {
       }
     }
   }
+}
+
+/// As [try_cast_slice](try_cast_slice), but unwraps the result for you.
+pub fn cast_slice<A: Pod, B: Pod>(s: &[A]) -> &[B] {
+  try_cast_slice(s).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,22 +3,89 @@
 
 //! Lokathor's crate of core-only odds and ends.
 
-use core::{num::*, ptr::NonNull};
+use core::{
+  mem::{align_of, size_of},
+  num::*,
+  ptr::NonNull,
+};
 
-/// A trait for "plain old data".
+macro_rules! impl_unsafe_marker_for_array {
+  ( $marker:ident , $( $n:expr ),* ) => {
+    $(unsafe impl<T> $marker for [T; $n] where T: $marker {})*
+  }
+}
+
+/// A trait for types that can be safely made with [zeroed](core::mem::zeroed).
 ///
 /// ## Safety
 ///
-/// * The type must allow **any** bit pattern (eg: no `bool` or `char`).
-/// * The type must **not** contain any padding bytes (eg: no `(u8, u16)`).
+/// * Your type must be inhabited (eg: no
+///   [Infallible](core::convert::Infallible)).
+/// * Your type must be allowed to be an "all zeroes" bit pattern (eg: no
+///   [NonNull<T>](core::ptr::NonNull)).
+pub unsafe trait Zeroable: Sized {
+  /// Calls [zeroed](core::mem::zeroed).
+  ///
+  /// This is a trait method so that you can write `MyType::zeroed()` in your
+  /// code. It is a contract of this trait that if you implement it on your type
+  /// you _must not_ override this method.
+  fn zeroed() -> Self {
+    unsafe { core::mem::zeroed() }
+  }
+}
+unsafe impl Zeroable for () {}
+unsafe impl Zeroable for bool {}
+unsafe impl Zeroable for char {}
+unsafe impl Zeroable for u8 {}
+unsafe impl Zeroable for i8 {}
+unsafe impl Zeroable for u16 {}
+unsafe impl Zeroable for i16 {}
+unsafe impl Zeroable for u32 {}
+unsafe impl Zeroable for i32 {}
+unsafe impl Zeroable for u64 {}
+unsafe impl Zeroable for i64 {}
+unsafe impl Zeroable for usize {}
+unsafe impl Zeroable for isize {}
+unsafe impl Zeroable for u128 {}
+unsafe impl Zeroable for i128 {}
+unsafe impl Zeroable for f32 {}
+unsafe impl Zeroable for f64 {}
+unsafe impl Zeroable for Option<NonZeroI8> {}
+unsafe impl Zeroable for Option<NonZeroI16> {}
+unsafe impl Zeroable for Option<NonZeroI32> {}
+unsafe impl Zeroable for Option<NonZeroI64> {}
+unsafe impl Zeroable for Option<NonZeroI128> {}
+unsafe impl Zeroable for Option<NonZeroIsize> {}
+unsafe impl Zeroable for Option<NonZeroU8> {}
+unsafe impl Zeroable for Option<NonZeroU16> {}
+unsafe impl Zeroable for Option<NonZeroU32> {}
+unsafe impl Zeroable for Option<NonZeroU64> {}
+unsafe impl Zeroable for Option<NonZeroU128> {}
+unsafe impl Zeroable for Option<NonZeroUsize> {}
+unsafe impl<T> Zeroable for *mut T {}
+unsafe impl<T> Zeroable for *const T {}
+unsafe impl<T> Zeroable for Option<NonNull<T>> {}
+impl_unsafe_marker_for_array!(
+  Zeroable, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+  24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256, 512, 1024
+);
+
+/// A marker trait for "plain old data".
+///
+/// The point of this trait is that once something is marked "plain old data"
+/// you can really go to town with the bit fiddling and bit casting. Therefore,
+/// it's a relatively strong claim to make about a type. Do not add this to your
+/// type casually.
+///
+/// ## Safety
+///
 /// * The type must be inhabited (eg: no
 ///   [Infallible](core::convert::Infallible)).
-///
-/// Generally, if you can't use a type with [zeroed](core::mem::zeroed) then it
-/// doesn't qualify for `Pod`, and if you can use it with `zeroed` then it
-/// _still might not_ qualify as `Pod`.
-pub unsafe trait Pod: Copy {}
+/// * The type must allow any bit pattern (eg: no `bool` or `char`).
+/// * The type must not contain any padding bytes (eg: no `(u8, u16)`).
+pub unsafe trait Pod: Zeroable + Copy {}
 
+unsafe impl Pod for () {}
 unsafe impl Pod for u8 {}
 unsafe impl Pod for i8 {}
 unsafe impl Pod for u16 {}
@@ -48,19 +115,58 @@ unsafe impl Pod for Option<NonZeroUsize> {}
 unsafe impl<T> Pod for *mut T {}
 unsafe impl<T> Pod for *const T {}
 unsafe impl<T> Pod for Option<NonNull<T>> {}
-macro_rules! impl_pod_array {
-  ( $( $n:expr ),* ) => {
-    $(unsafe impl<T> Pod for [T; $n] where T: Pod {})*
-  }
-}
-impl_pod_array!(
-  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
-  27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256, 512, 1024
+impl_unsafe_marker_for_array!(
+  Pod, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+  25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256, 512, 1024
 );
 
-/// Creates a zeroed value of the type.
-pub fn pod_zeroed<T: Pod>() -> T {
-  // This is safe because a POD must allow any bit pattern, thusly it allows a
-  // zeroed bit pattern.
-  unsafe { core::mem::zeroed() }
+/// As [try_cast_slice](try_cast_slice), but unwraps the result for you.
+pub fn cast_slice<A: Pod, B: Pod>(s: &[A]) -> &[B] {
+  try_cast_slice(s).unwrap()
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SliceCastError {
+  TargetAlignmentGreaterAndInputNotAligned,
+  CantConvertBetweenZSTAndNonZST,
+  OutputSliceWouldHaveSlop,
+}
+
+/// Try to convert a slice of one type into another.
+///
+/// * `input.as_ptr() as usize == output.as_ptr() as usize`
+///
+/// ## Failure
+///
+/// * If the target type has a greater alignment requirement and the input slice
+///   isn't aligned.
+/// * If the target element type is a different size from the current element
+///   type, and the output slice wouldn't be a whole number of elements when
+///   accounting for the size change (eg: three `u16` values is 1.5 `u32`
+///   values, so that's a failure).
+/// * Similarly, you can't convert between a
+///   [ZST](https://doc.rust-lang.org/nomicon/exotic-sizes.html#zero-sized-types-zsts)
+///   and a non-ZST.
+pub fn try_cast_slice<A: Pod, B: Pod>(a: &[A]) -> Result<&[B], SliceCastError> {
+  if align_of::<B>() > align_of::<A>() && (a.as_ptr() as *const A as usize) % align_of::<B>() != 0 {
+    // If the alignment requirement goes up then we check for possible
+    // mis-alignment and error out if that's the case.
+    Err(SliceCastError::TargetAlignmentGreaterAndInputNotAligned)
+  } else {
+    if size_of::<B>() == size_of::<A>() {
+      // If the sizes are the same this is a totally plain cast, even for ZST
+      Ok(unsafe { core::slice::from_raw_parts(a.as_ptr() as *const B, a.len()) })
+    } else if size_of::<A>() == 0 || size_of::<B>() == 0 {
+      // If the sizes aren't the same and one of them is a ZST, this is
+      // hopeless.
+      Err(SliceCastError::CantConvertBetweenZSTAndNonZST)
+    } else {
+      if core::mem::size_of_val(a) % size_of::<B>() != 0 {
+        Err(SliceCastError::OutputSliceWouldHaveSlop)
+      } else {
+        let new_len = core::mem::size_of_val(a) / size_of::<B>();
+        Ok(unsafe { core::slice::from_raw_parts(a.as_ptr() as *const B, new_len) })
+      }
+    }
+  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,10 +125,20 @@ pub fn cast_slice<A: Pod, B: Pod>(s: &[A]) -> &[B] {
   try_cast_slice(s).unwrap()
 }
 
+/// The things that can go wrong when casting a slice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SliceCastError {
+  /// You tried to cast a slice to an element type with a higher alignment
+  /// requirement but the slice wasn't aligned.
   TargetAlignmentGreaterAndInputNotAligned,
+  /// You tried to cast between a zero-sized type and a non-zero-sized type.
+  /// Because the output slice resizes based on the input and output types, it's
+  /// fairly nonsensical to throw a ZST into the mix. You can go from a ZST to
+  /// another ZST, if you want.
   CantConvertBetweenZSTAndNonZST,
+  /// If the element size changes then the output slice changes length
+  /// accordingly. If the output slice wouldn't be a whole number of elements
+  /// then the conversion fails.
   OutputSliceWouldHaveSlop,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,6 +178,6 @@ pub fn try_cast_slice<A: Pod, B: Pod>(a: &[A]) -> Result<&[B], SliceCastError> {
 }
 
 /// As [try_cast_slice](try_cast_slice), but unwraps the result for you.
-pub fn cast_slice<A: Pod, B: Pod>(s: &[A]) -> &[B] {
-  try_cast_slice(s).unwrap()
+pub fn cast_slice<A: Pod, B: Pod>(a: &[A]) -> &[B] {
+  try_cast_slice(a).unwrap()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,3 +201,12 @@ pub fn try_cast_slice_mut<A: Pod, B: Pod>(a: &mut [A]) -> Result<&mut [B], Slice
 pub fn cast_slice_mut<A: Pod, B: Pod>(a: &[A]) -> &[B] {
   try_cast_slice(a).unwrap()
 }
+
+/// Re-interprets a reference as a byte slice reference.
+///
+/// ## Panics
+///
+/// * If `T` is a ZST.
+pub fn bytes_of<T: Pod>(t: &T) -> &[u8] {
+  cast_slice::<T, u8>(core::slice::from_ref(t))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,16 +155,11 @@ pub enum SliceCastError {
 ///   and a non-ZST.
 pub fn try_cast_slice<A: Pod, B: Pod>(a: &[A]) -> Result<&[B], SliceCastError> {
   if align_of::<B>() > align_of::<A>() && (a.as_ptr() as *const A as usize) % align_of::<B>() != 0 {
-    // If the alignment requirement goes up then we check for possible
-    // mis-alignment and error out if that's the case.
     Err(SliceCastError::TargetAlignmentGreaterAndInputNotAligned)
   } else {
     if size_of::<B>() == size_of::<A>() {
-      // If the sizes are the same this is a totally plain cast, even for ZST
       Ok(unsafe { core::slice::from_raw_parts(a.as_ptr() as *const B, a.len()) })
     } else if size_of::<A>() == 0 || size_of::<B>() == 0 {
-      // If the sizes aren't the same and one of them is a ZST, this is
-      // hopeless.
       Err(SliceCastError::CantConvertBetweenZSTAndNonZST)
     } else {
       if core::mem::size_of_val(a) % size_of::<B>() != 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 
 use core::{
   mem::{align_of, size_of},
+  marker::PhantomData,
   num::*,
   ptr::NonNull,
 };
@@ -74,6 +75,7 @@ unsafe impl Zeroable for Option<NonZeroUsize> {}
 unsafe impl<T> Zeroable for *mut T {}
 unsafe impl<T> Zeroable for *const T {}
 unsafe impl<T> Zeroable for Option<NonNull<T>> {}
+unsafe impl<T> Zeroable for PhantomData<T> where T: Zeroable {}
 impl_unsafe_marker_for_array!(
   Zeroable, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
   24, 25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256, 512, 1024
@@ -124,6 +126,7 @@ unsafe impl Pod for Option<NonZeroUsize> {}
 unsafe impl<T> Pod for *mut T {}
 unsafe impl<T> Pod for *const T {}
 unsafe impl<T> Pod for Option<NonNull<T>> {}
+unsafe impl<T> Pod for PhantomData<T> where T: Pod {}
 impl_unsafe_marker_for_array!(
   Pod, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
   25, 26, 27, 28, 29, 30, 31, 32, 48, 64, 96, 128, 256, 512, 1024

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -1,0 +1,77 @@
+use core::mem::size_of;
+
+use lokacore::*;
+
+#[test]
+fn test_try_cast_slice() {
+  // some align4 data
+  let u32_slice: &[u32] = &[4, 5, 6];
+  // the same data as align1
+  let the_bytes: &[u8] = try_cast_slice(u32_slice).unwrap();
+
+  assert_eq!(
+    u32_slice.as_ptr() as *const u32 as usize,
+    the_bytes.as_ptr() as *const u8 as usize
+  );
+  assert_eq!(
+    u32_slice.len() * size_of::<u32>(),
+    the_bytes.len() * size_of::<u8>()
+  );
+
+  // by taking one byte off the front, we're definitely mis-aligned for u32.
+  let mis_aligned_bytes = &the_bytes[1..];
+  assert_eq!(
+    try_cast_slice::<u8, u32>(mis_aligned_bytes),
+    Err(SliceCastError::TargetAlignmentGreaterAndInputNotAligned)
+  );
+
+  // by taking one byte off the end, we're aligned but would have slop bytes for u32
+  let the_bytes_len_minus1 = the_bytes.len() - 1;
+  let slop_bytes = &the_bytes[..the_bytes_len_minus1];
+  assert_eq!(
+    try_cast_slice::<u8, u32>(slop_bytes),
+    Err(SliceCastError::OutputSliceWouldHaveSlop)
+  );
+
+  // if we don't mess with it we can up-alignment cast
+  try_cast_slice::<u8, u32>(the_bytes).unwrap();
+}
+
+#[test]
+fn test_try_cast_slice_mut() {
+  // some align4 data
+  let u32_slice: &mut [u32] = &mut [4, 5, 6];
+  let u32_len = u32_slice.len();
+  let u32_ptr = u32_slice.as_ptr();
+  // the same data as align1
+  let the_bytes: &mut [u8] = try_cast_slice_mut(u32_slice).unwrap();
+  let the_bytes_len = the_bytes.len();
+  let the_bytes_ptr = the_bytes.as_ptr();
+
+  assert_eq!(
+    u32_ptr as *const u32 as usize,
+    the_bytes_ptr as *const u8 as usize
+  );
+  assert_eq!(
+    u32_len * size_of::<u32>(),
+    the_bytes_len * size_of::<u8>()
+  );
+
+  // by taking one byte off the front, we're definitely mis-aligned for u32.
+  let mis_aligned_bytes = &mut the_bytes[1..];
+  assert_eq!(
+    try_cast_slice_mut::<u8, u32>(mis_aligned_bytes),
+    Err(SliceCastError::TargetAlignmentGreaterAndInputNotAligned)
+  );
+
+  // by taking one byte off the end, we're aligned but would have slop bytes for u32
+  let the_bytes_len_minus1 = the_bytes.len() - 1;
+  let slop_bytes = &mut the_bytes[..the_bytes_len_minus1];
+  assert_eq!(
+    try_cast_slice_mut::<u8, u32>(slop_bytes),
+    Err(SliceCastError::OutputSliceWouldHaveSlop)
+  );
+
+  // if we don't mess with it we can up-alignment cast
+  try_cast_slice_mut::<u8, u32>(the_bytes).unwrap();
+}

--- a/tests/cast_slice_tests.rs
+++ b/tests/cast_slice_tests.rs
@@ -52,10 +52,7 @@ fn test_try_cast_slice_mut() {
     u32_ptr as *const u32 as usize,
     the_bytes_ptr as *const u8 as usize
   );
-  assert_eq!(
-    u32_len * size_of::<u32>(),
-    the_bytes_len * size_of::<u8>()
-  );
+  assert_eq!(u32_len * size_of::<u32>(), the_bytes_len * size_of::<u8>());
 
   // by taking one byte off the front, we're definitely mis-aligned for u32.
   let mis_aligned_bytes = &mut the_bytes[1..];


### PR DESCRIPTION
TODOs before final merge:

* [x] ~~Comment out the `Option<NonZeroU8>` and similar for the other integer types if the Unsafe Code Group can't decide if it's correct or not to include them. We'll give them a little longer to try and figure this one out, and we can also add it back in at any future point.~~ It seems that due to https://github.com/rust-lang/rust/pull/60300, we're in the clear when transmuting _specifically_ those `NonZeroFoo` types (though not all possible "one niche + Option" types).