### PR TITLE
rdtsc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ git:
   quiet: true
 
 rust:
-  - stable
+  - 1.36.0
   - beta
   - nightly
 
@@ -27,6 +27,6 @@ matrix:
 
 script:
   - rustup component add clippy
-  - cargo clippy --all --all-features --all-targets -- -D warnings
-  - cargo -vv build
-  - cargo -vv test
+  - cargo clippy
+  - cargo build
+  - cargo test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![License:0BSD](https://img.shields.io/badge/License-0BSD-brightgreen.svg)](https://opensource.org/licenses/FPL-1.0.0)
+![Minimum Rust Version](https://img.shields.io/badge/Min%20Rust-1.34-green.svg)
 [![travis.ci](https://travis-ci.org/Lokathor/lokacore.svg?branch=master)](https://travis-ci.org/Lokathor/lokacore)
 [![AppVeyor](https://ci.appveyor.com/api/projects/status/td70y0cavp51giai/branch/master?svg=true)](https://ci.appveyor.com/project/Lokathor/lokacore/branch/master)
 [![crates.io](https://img.shields.io/crates/v/lokacore.svg)](https://crates.io/crates/lokacore)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,12 +14,12 @@ matrix:
 
 environment:
   matrix:
-    - channel: stable
+    - channel: 1.34.0
       target: x86_64-pc-windows-msvc
+    - channel: 1.34.0
+      target: x86_64-pc-windows-gnu
     - channel: beta
       target: x86_64-pc-windows-msvc
-    - channel: stable
-      target: x86_64-pc-windows-gnu
     - channel: beta
       target: x86_64-pc-windows-gnu
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,9 +14,9 @@ matrix:
 
 environment:
   matrix:
-    - channel: 1.34.0
+    - channel: 1.36.0
       target: x86_64-pc-windows-msvc
-    - channel: 1.34.0
+    - channel: 1.36.0
       target: x86_64-pc-windows-gnu
     - channel: beta
       target: x86_64-pc-windows-msvc
@@ -35,6 +35,6 @@ install:
 build: false
 
 test_script:
-  - cargo clippy --all --all-features --all-targets -- -D warnings
-  - cargo -vv build
-  - cargo -vv test
+  - cargo clippy
+  - cargo build
+  - cargo test

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,0 +1,7 @@
+//! Architecture specific functionality.
+
+#[cfg(target_arch="x86")]
+pub mod x86;
+
+#[cfg(target_arch="x86_64")]
+pub mod x86_64;

--- a/src/arch/x86.rs
+++ b/src/arch/x86.rs
@@ -1,0 +1,9 @@
+//! Intrinsics for the [x86](https://en.wikipedia.org/wiki/X86) processor family.
+
+/// As [_rdtsc](core::arch::x86::_rdtsc), just marked safe since it's always safe.
+#[inline]
+pub fn rdtsc() -> u64 {
+  unsafe {
+    core::arch::x86::_rdtsc()
+  }
+}

--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,0 +1,9 @@
+//! Intrinsics for the [x86_64](https://en.wikipedia.org/wiki/X86-64) processor family.
+
+/// As [_rdtsc](core::arch::x86_64::_rdtsc), just marked safe since it's always safe.
+#[inline]
+pub fn rdtsc() -> u64 {
+  unsafe {
+    core::arch::x86_64::_rdtsc()
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,20 @@ macro_rules! branchless_max {
   };
 }
 
+/// Calls the `rdtsc` intrinsic.
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline]
+pub fn rdtsc() -> u64 {
+  #[cfg(target_arch = "x86")]
+  unsafe {
+    core::arch::x86::_rdtsc()
+  }
+  #[cfg(target_arch = "x86_64")]
+  unsafe {
+    core::arch::x86_64::_rdtsc()
+  }
+}
+
 /// Implements an unsafe marker trait on an array type if the element type
 /// also supports that marker trait.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,11 +36,11 @@ macro_rules! branchless_max {
 pub fn rdtsc() -> u64 {
   #[cfg(target_arch = "x86")]
   unsafe {
-    core::arch::x86::_rdtsc()
+    core::arch::x86::_rdtsc() as u64
   }
   #[cfg(target_arch = "x86_64")]
   unsafe {
-    core::arch::x86_64::_rdtsc()
+    core::arch::x86_64::_rdtsc() as u64
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ macro_rules! branchless_max {
   };
 }
 
-/// Calls the `rdtsc` intrinsic.
+/// [`x86`/`x86_64`]: Calls the `rdtsc` intrinsic.
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[inline]
 pub fn rdtsc() -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use core::{
 /// Works for any integral type.
 #[macro_export]
 macro_rules! branchless_min {
-  ($x:expr, $y:expr, $u:ty) => {
+  ($x:ident, $y:ident, $u:ty) => {
     $y ^ (($x ^ $y) & (<$u>::wrapping_neg(($x < $y) as $u)))
   };
 }
@@ -25,7 +25,7 @@ macro_rules! branchless_min {
 /// Works for any integral type.
 #[macro_export]
 macro_rules! branchless_max {
-  ($x:expr, $y:expr, $u:ty) => {
+  ($x:ident, $y:ident, $u:ty) => {
     $x ^ (($x ^ $y) & (<$u>::wrapping_neg(($x < $y) as $u)))
   };
 }


### PR DESCRIPTION
* [x] sort out the RDTSC return type (this is up in the air, probably will change with 1.36)