### PR TITLE
travis: Build android, ios, wasm, and linux release builds.

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,39 @@
 [build]
 rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=native"]
+
+
+
+# Building for Android requires different settings for windows vs linux hosts.
+# See scripts/*-android/.cargo/config for host-specific android cargo config.
+
+
+
+# iOS targets can't use target-cpu=native without warnings
+
+[target.aarch64-apple-ios] # Apple A7 and later
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.armv7-apple-ios] # Apple A5 and earlier
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.armv7s-apple-ios] # Apple A6 and A6X chips (iPhone 5, iPhone 5C and iPad 4)
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.i386-apple-ios] # Emulators
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.x86_64-apple-ios] # Emulators
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+
+
+# WASM targets can't use target-cpu=native without warnings either
+
+[target.wasm32-unknown-emscripten]
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.wasm32-unknown-unknown]
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.wasm32-wasi]
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,5 @@
 [build]
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=native"]
+rustflags = ["-C","target-cpu=native"]
 
 
 
@@ -11,29 +11,29 @@ rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=native"]
 # iOS targets can't use target-cpu=native without warnings
 
 [target.aarch64-apple-ios] # Apple A7 and later
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.armv7-apple-ios] # Apple A5 and earlier
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.armv7s-apple-ios] # Apple A6 and A6X chips (iPhone 5, iPhone 5C and iPad 4)
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.i386-apple-ios] # Emulators
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.x86_64-apple-ios] # Emulators
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 
 
 # WASM targets can't use target-cpu=native without warnings either
 
 [target.wasm32-unknown-emscripten]
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.wasm32-unknown-unknown]
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.wasm32-wasi]
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]

--- a/.cargo/config
+++ b/.cargo/config
@@ -27,6 +27,11 @@ rustflags = ["-C","target-cpu=generic"]
 
 
 
+# Linux targets may or may not be cross-compiling.  Assume we're not.
+# Travis will use scripts/generic-cross/.cargo/config to avoid warnings when cross compiling.
+
+
+
 # WASM targets can't use target-cpu=native without warnings either
 
 [target.wasm32-unknown-emscripten]

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,10 @@ matrix:
     - rust: nightly
   include:
     - { os: linux, rust: 1.36.0,  env: FLAGS=--release }
-    - { os: linux, rust: beta,    env: FLAGS=--release }
-    - { os: linux, rust: nightly, env: FLAGS=--release }
+    #- { os: linux, rust: beta,    env: FLAGS=--release }
+    #- { os: linux, rust: nightly, env: FLAGS=--release }
 
-    #- { os: osx, rust: 1.36.0,  env: FLAGS=--release }
+    - { os: osx, rust: 1.36.0,  env: FLAGS=--release }
     #- { os: osx, rust: beta,    env: FLAGS=--release }
     #- { os: osx, rust: nightly, env: FLAGS=--release }
 
@@ -47,10 +47,19 @@ matrix:
     - { os: linux, rust: 1.36.0,  env: TARGET=armv7-linux-androideabi }
     #- { os: linux, rust: beta,    env: TARGET=armv7-linux-androideabi }
     #- { os: linux, rust: nightly, env: TARGET=armv7-linux-androideabi }
-    #- { os: linux, rust: 1.36.0,  env: TARGET=i686-linux-android }
+    - { os: linux, rust: 1.36.0,  env: TARGET=i686-linux-android }
     #- { os: linux, rust: beta,    env: TARGET=i686-linux-android }
     #- { os: linux, rust: nightly, env: TARGET=i686-linux-android }
-    #- { os: linux, rust: 1.36.0,  env: TARGET=x86_64-linux-android }
+    - { os: linux, rust: 1.36.0,  env: TARGET=x86_64-linux-android }
+    #- { os: linux, rust: beta,    env: TARGET=x86_64-linux-android }
+    #- { os: linux, rust: nightly, env: TARGET=x86_64-linux-android }
+    - { os: linux, rust: 1.36.0,  env: TARGET=arm-unknown-linux-gnueabihf }
+    #- { os: linux, rust: beta,    env: TARGET=arm-unknown-linux-gnueabihf }
+    #- { os: linux, rust: nightly, env: TARGET=arm-unknown-linux-gnueabihf }
+    - { os: linux, rust: 1.36.0,  env: TARGET=armv7-unknown-linux-gnueabihf }
+    #- { os: linux, rust: beta,    env: TARGET=armv7-unknown-linux-gnueabihf }
+    #- { os: linux, rust: nightly, env: TARGET=armv7-unknown-linux-gnueabihf }
+    - { os: linux, rust: 1.36.0,  env: TARGET=thumbv7neon-unknown-linux-gnueabihf }
     #- { os: linux, rust: beta,    env: TARGET=x86_64-linux-android }
     #- { os: linux, rust: nightly, env: TARGET=x86_64-linux-android }
 
@@ -60,13 +69,13 @@ matrix:
     - { os: osx,   rust: 1.36.0,  env: TARGET=armv7-apple-ios }
     #- { os: osx,   rust: beta,    env: TARGET=armv7-apple-ios }
     #- { os: osx,   rust: nightly, env: TARGET=armv7-apple-ios }
-    #- { os: osx,   rust: 1.36.0,  env: TARGET=armv7s-apple-ios }
+    - { os: osx,   rust: 1.36.0,  env: TARGET=armv7s-apple-ios }
     #- { os: osx,   rust: beta,    env: TARGET=armv7s-apple-ios }
     #- { os: osx,   rust: nightly, env: TARGET=armv7s-apple-ios }
-    #- { os: osx,   rust: 1.36.0,  env: TARGET=i386-apple-ios }
+    - { os: osx,   rust: 1.36.0,  env: TARGET=i386-apple-ios }
     #- { os: osx,   rust: beta,    env: TARGET=i386-apple-ios }
     #- { os: osx,   rust: nightly, env: TARGET=i386-apple-ios }
-    #- { os: osx,   rust: 1.36.0,  env: TARGET=x86_64-apple-ios }
+    - { os: osx,   rust: 1.36.0,  env: TARGET=x86_64-apple-ios }
     #- { os: osx,   rust: beta,    env: TARGET=x86_64-apple-ios }
     #- { os: osx,   rust: nightly, env: TARGET=x86_64-apple-ios }
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rust:
 os:
   - linux
   - osx
+  #- windows # Works, but already covered by appveyor and takes 7+ minutes (always) vs appveyor's <1 minute.
 
 branches:
   only:
@@ -23,10 +24,62 @@ branches:
 matrix:
   fast_finish: true
   allow_failures:
-  - rust: nightly
+    - rust: nightly
+  include:
+    - { os: linux, rust: 1.36.0,  env: FLAGS=--release }
+    - { os: linux, rust: beta,    env: FLAGS=--release }
+    - { os: linux, rust: nightly, env: FLAGS=--release }
+
+    #- { os: osx, rust: 1.36.0,  env: FLAGS=--release }
+    #- { os: osx, rust: beta,    env: FLAGS=--release }
+    #- { os: osx, rust: nightly, env: FLAGS=--release }
+
+    - { os: linux, rust: 1.36.0,  env: TARGET=wasm32-unknown-unknown }
+    #- { os: linux, rust: beta,    env: TARGET=wasm32-unknown-unknown }
+    #- { os: linux, rust: nightly, env: TARGET=wasm32-unknown-unknown }
+    - { os: linux, rust: 1.36.0,  env: TARGET=wasm32-wasi }
+    #- { os: linux, rust: beta,    env: TARGET=wasm32-wasi }
+    #- { os: linux, rust: nightly, env: TARGET=wasm32-wasi }
+
+    - { os: linux, rust: 1.36.0,  env: TARGET=aarch64-linux-android }
+    #- { os: linux, rust: beta,    env: TARGET=aarch64-linux-android }
+    #- { os: linux, rust: nightly, env: TARGET=aarch64-linux-android }
+    - { os: linux, rust: 1.36.0,  env: TARGET=armv7-linux-androideabi }
+    #- { os: linux, rust: beta,    env: TARGET=armv7-linux-androideabi }
+    #- { os: linux, rust: nightly, env: TARGET=armv7-linux-androideabi }
+    #- { os: linux, rust: 1.36.0,  env: TARGET=i686-linux-android }
+    #- { os: linux, rust: beta,    env: TARGET=i686-linux-android }
+    #- { os: linux, rust: nightly, env: TARGET=i686-linux-android }
+    #- { os: linux, rust: 1.36.0,  env: TARGET=x86_64-linux-android }
+    #- { os: linux, rust: beta,    env: TARGET=x86_64-linux-android }
+    #- { os: linux, rust: nightly, env: TARGET=x86_64-linux-android }
+
+    - { os: osx,   rust: 1.36.0,  env: TARGET=aarch64-apple-ios }
+    #- { os: osx,   rust: beta,    env: TARGET=aarch64-apple-ios }
+    #- { os: osx,   rust: nightly, env: TARGET=aarch64-apple-ios }
+    - { os: osx,   rust: 1.36.0,  env: TARGET=armv7-apple-ios }
+    #- { os: osx,   rust: beta,    env: TARGET=armv7-apple-ios }
+    #- { os: osx,   rust: nightly, env: TARGET=armv7-apple-ios }
+    #- { os: osx,   rust: 1.36.0,  env: TARGET=armv7s-apple-ios }
+    #- { os: osx,   rust: beta,    env: TARGET=armv7s-apple-ios }
+    #- { os: osx,   rust: nightly, env: TARGET=armv7s-apple-ios }
+    #- { os: osx,   rust: 1.36.0,  env: TARGET=i386-apple-ios }
+    #- { os: osx,   rust: beta,    env: TARGET=i386-apple-ios }
+    #- { os: osx,   rust: nightly, env: TARGET=i386-apple-ios }
+    #- { os: osx,   rust: 1.36.0,  env: TARGET=x86_64-apple-ios }
+    #- { os: osx,   rust: beta,    env: TARGET=x86_64-apple-ios }
+    #- { os: osx,   rust: nightly, env: TARGET=x86_64-apple-ios }
 
 script:
-  - rustup component add clippy
-  - cargo clippy
-  - cargo build
-  - cargo test
+  - pushd scripts
+  - ./travis.sh
+  - popd
+
+# Configured so we cache cargo-web for WASM unit testing, otherwise it takes forever (13+ minutes) to compile.
+# See also https://levans.fr/rust_travis_cache.html
+cache:
+  directories:
+    - $TRAVIS_HOME/.cargo/
+    - $TRAVIS_HOME/.rustup/
+before_cache:
+  - rm -rf "$TRAVIS_HOME/.cargo/registry/src"

--- a/scripts/generic-cross/.cargo/config
+++ b/scripts/generic-cross/.cargo/config
@@ -1,0 +1,4 @@
+# Don't generate CPU mismatch warnings when cross-compiling
+
+[build]
+rustflags = ["-C","target-cpu=generic"]

--- a/scripts/generic-cross/.cargo/config
+++ b/scripts/generic-cross/.cargo/config
@@ -1,4 +1,16 @@
 # Don't generate CPU mismatch warnings when cross-compiling
 
-[build]
+[target.arm-unknown-linux-gnueabihf]
+ar     = "arm-linux-gnueabihf-ar"
+linker = "arm-linux-gnueabihf-gcc"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.armv7-unknown-linux-gnueabihf]
+ar     = "arm-linux-gnueabihf-ar"
+linker = "arm-linux-gnueabihf-gcc"
+rustflags = ["-C","target-cpu=generic"]
+
+[target.thumbv7neon-unknown-linux-gnueabihf]
+ar     = "arm-linux-gnueabihf-ar"
+linker = "arm-linux-gnueabihf-gcc"
 rustflags = ["-C","target-cpu=generic"]

--- a/scripts/linux-android/.cargo/config
+++ b/scripts/linux-android/.cargo/config
@@ -3,19 +3,19 @@
 [target.aarch64-linux-android]
 ar = "aarch64-linux-android-ar"
 linker = "aarch64-linux-android21-clang"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.armv7-linux-androideabi]
 ar = "armv7a-linux-androideabi-ar"
 linker = "armv7a-linux-androideabi21-clang"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.i686-linux-android]
 ar = "i686-linux-android-ar"
 linker = "i686-linux-android21-clang"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.x86_64-linux-android]
 ar = "x86_64-linux-android-ar"
 linker = "x86_64-linux-android21-clang"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]

--- a/scripts/linux-android/.cargo/config
+++ b/scripts/linux-android/.cargo/config
@@ -1,0 +1,21 @@
+# Android ar/linker/flags config for when building on linux.
+
+[target.aarch64-linux-android]
+ar = "aarch64-linux-android-ar"
+linker = "aarch64-linux-android21-clang"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.armv7-linux-androideabi]
+ar = "armv7a-linux-androideabi-ar"
+linker = "armv7a-linux-androideabi21-clang"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.i686-linux-android]
+ar = "i686-linux-android-ar"
+linker = "i686-linux-android21-clang"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.x86_64-linux-android]
+ar = "x86_64-linux-android-ar"
+linker = "x86_64-linux-android21-clang"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -e
 
 rustup component add clippy
@@ -24,10 +26,13 @@ elif [[ "$TARGET" == *"-apple-ios" || "$TARGET" == "wasm32-wasi" ]]; then
   #   cargo-web doesn't support wasm32-wasi yet, nor can wasm-pack test specify a target
 
 elif [[ "$TARGET" != "" ]]; then
-  cargo build --target=$TARGET $FLAGS
-  cargo test  --target=$TARGET $FLAGS
+  pushd generic-cross
+    cargo build --target=$TARGET $FLAGS
+    cargo test  --target=$TARGET $FLAGS
+  popd
 
 else
+  # Push nothing, target host CPU architecture
   cargo build $FLAGS
   cargo test  $FLAGS
 

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,0 +1,34 @@
+set -e
+
+rustup component add clippy
+cargo clippy
+
+if [[ "$TARGET" != "" ]]; then rustup target install $TARGET; fi
+
+if [[ "$TARGET" == "wasm32-"* && "$TARGET" != "wasm32-wasi" ]]; then
+  cargo-web --version || cargo install cargo-web
+  cargo web build $FLAGS --target=$TARGET
+  cargo web test  $FLAGS --target=$TARGET
+
+elif [[ "$TARGET" == *"-linux-android"* ]]; then
+  export PATH=/usr/local/android-sdk/ndk-bundle/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
+  pushd linux-android
+    cargo build --target=$TARGET
+    # Don't test, can't run android emulators successfully on travis currently
+  popd
+
+elif [[ "$TARGET" == *"-apple-ios" || "$TARGET" == "wasm32-wasi" ]]; then
+  cargo build --target=$TARGET $FLAGS
+  # Don't test
+  #   iOS simulator setup/teardown is complicated
+  #   cargo-web doesn't support wasm32-wasi yet, nor can wasm-pack test specify a target
+
+elif [[ "$TARGET" != "" ]]; then
+  cargo build --target=$TARGET $FLAGS
+  cargo test  --target=$TARGET $FLAGS
+
+else
+  cargo build $FLAGS
+  cargo test  $FLAGS
+
+fi

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -25,6 +25,14 @@ elif [[ "$TARGET" == *"-apple-ios" || "$TARGET" == "wasm32-wasi" ]]; then
   #   iOS simulator setup/teardown is complicated
   #   cargo-web doesn't support wasm32-wasi yet, nor can wasm-pack test specify a target
 
+elif [[ "$TARGET" == *"-unknown-linux-gnueabihf" ]]; then
+  #sudo apt-get update
+  #sudo apt-get install -y gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+  pushd generic-cross
+    cargo build --target=$TARGET $FLAGS
+    # Don't test
+  popd
+
 elif [[ "$TARGET" != "" ]]; then
   pushd generic-cross
     cargo build --target=$TARGET $FLAGS

--- a/scripts/windows-android/.cargo/config
+++ b/scripts/windows-android/.cargo/config
@@ -1,0 +1,21 @@
+# Android ar/linker/flags config for when building on windows.
+
+[target.aarch64-linux-android]
+ar = "aarch64-linux-android-ar.cmd"
+linker = "aarch64-linux-android21-clang.cmd"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.armv7-linux-androideabi]
+ar = "armv7a-linux-androideabi-ar.cmd"
+linker = "armv7a-linux-androideabi21-clang.cmd"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.i686-linux-android]
+ar = "i686-linux-android-ar.cmd"
+linker = "i686-linux-android21-clang.cmd"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+
+[target.x86_64-linux-android]
+ar = "x86_64-linux-android-ar.cmd"
+linker = "x86_64-linux-android21-clang.cmd"
+rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]

--- a/scripts/windows-android/.cargo/config
+++ b/scripts/windows-android/.cargo/config
@@ -3,19 +3,19 @@
 [target.aarch64-linux-android]
 ar = "aarch64-linux-android-ar.cmd"
 linker = "aarch64-linux-android21-clang.cmd"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.armv7-linux-androideabi]
 ar = "armv7a-linux-androideabi-ar.cmd"
 linker = "armv7a-linux-androideabi21-clang.cmd"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.i686-linux-android]
 ar = "i686-linux-android-ar.cmd"
 linker = "i686-linux-android21-clang.cmd"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]
 
 [target.x86_64-linux-android]
 ar = "x86_64-linux-android-ar.cmd"
 linker = "x86_64-linux-android21-clang.cmd"
-rustflags = ["-C","target-feature=+crt-static","-C","target-cpu=generic"]
+rustflags = ["-C","target-cpu=generic"]


### PR DESCRIPTION
I left the existing matrix of (linux, osx) x (1.36.0, beta, nightly) alone, but I could convert them to the matrix/include style for consistency with everything else if you'd like.  Ideally we'd be able to specify os=android or similar and not need to specify everything manually in include, but no dice - it specifies the host OS only.  Fortunately, the include style makes it easier to pick and choose builds to get a nice balance of coverage vs build times.

Most of the new build configs in .travis.yml are commented out to disable them, but they've been mostly tested  If you want more/less just uncomment/comment to taste.  Travis builds 2-4 jobs in parallel, each target takes about a minute (if not installing cargo-web when missing from cache, and not building windows), so for another 8+ minutes of waiting you could uncomment everything.

Some of the build history can be seen here as I experimented with settings:  https://travis-ci.org/MaulingMonkey/lokacore/builds